### PR TITLE
[screen] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/rpm/screen.spec
+++ b/rpm/screen.spec
@@ -12,6 +12,7 @@ Patch1:     screen-4.7.0-screenrc.patch
 Patch2:     screen-4.7.0-maxstr.patch
 Requires(pre):  /usr/sbin/groupadd
 BuildRequires:  pkgconfig(ncurses)
+BuildRequires:  pkgconfig(libcrypt)
 BuildRequires:  pam-devel
 BuildRequires:  libutempter-devel
 BuildRequires:  autoconf


### PR DESCRIPTION
screen depdends on pkconfig(libcrypt) for the crypt import but it was
not included. This fails when pkconfig(libcrypt) is not bundled in the glib-devel package.